### PR TITLE
feat: hoist complex function arguments from partials

### DIFF
--- a/src/index.lsc
+++ b/src/index.lsc
@@ -38,9 +38,20 @@ module.exports = ({ types: t }) ->
     t.isSpreadElement(node) and
     isPlaceholder(node.argument, placeholder)
 
+  isPartialCaller (node, placeholder) ->
+    t.isCallExpression(node) and
+    hasPlaceholders(node.arguments, placeholder)
+
   isCalleePlaceholder (node, placeholder) ->
     t.isCallExpression(node) and
     isPlaceholder(node.callee.object, placeholder)
+
+  shouldHoist (node) ->
+    !t.isLiteral(node) and [
+      'Identifier'
+      'FunctionExpression'
+      'ArrowFunctionExpression'
+    ].every(type => type != node.type)
 
   hasPlaceholders (nodes, placeholder) ->
     for elem node in nodes:
@@ -87,6 +98,19 @@ module.exports = ({ types: t }) ->
         name = getUniqueName(path)
         remainingParams.push(t.restElement(name))
         return t.spreadElement(name)
+
+      if shouldHoist(arg):
+        if isPartialCaller(arg, placeholder):
+          return arg
+
+        id = getUniqueName(path, 'ref')
+        ref = t.variableDeclaration('const', [
+          t.variableDeclarator(id, arg)
+        ])
+
+        parent = path.getStatementParent()
+        parent.insertBefore(ref)
+        return id
 
       arg
     )

--- a/tests/fixtures/various-arg-types/expected.js
+++ b/tests/fixtures/various-arg-types/expected.js
@@ -2,8 +2,12 @@ const something = [];
 const foo = () => 42;
 const H = class {};
 
+const _ref = foo();
+
+const _ref2 = new H();
+
 const partial = (_a, _a2) => {
-  return fn(_a, 1, _a2, true, null, 'some string', undefined, something, foo(), new H(), () => {});
+  return fn(_a, 1, _a2, true, null, 'some string', undefined, something, _ref, _ref2, () => {});
 };
 
 partial('hello', 'world');


### PR DESCRIPTION
Prevent things like function calls and new expressions from being run each time a partial is called by hoisting them out of the generated partial function. 